### PR TITLE
chore: update coingecko url for pro plan MGX-1182

### DIFF
--- a/.github/workflows/reusable-rust-build.yml
+++ b/.github/workflows/reusable-rust-build.yml
@@ -4,13 +4,14 @@ on:
       rust-version:
         type: string
         required: false
-        default: stable
+        default: 1.78.0
+
       version:
         description: Version to be assigned to the built image
         required: true
         type: string
       cache-version:
-        default: 0
+        default: 1
         description: Cache version variable to be used to invalidate cache when needed
         required: false
         type: number
@@ -34,7 +35,7 @@ jobs:
       - name: Check formatting
         working-directory: avs-finalizer
         run: cargo fmt --all -- --check
-  
+
   clippy-check:
     name: Clippy check
     runs-on: compile-eigen-gke
@@ -47,7 +48,7 @@ jobs:
           override: true
           components: rustfmt, clippy
       - uses: arduino/setup-protoc@v3
-      
+
       - uses: google-github-actions/auth@v2
         with:
           workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
@@ -63,7 +64,7 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
           key: cargo-rollup-clippy-cache-${{ inputs.cache_version }}-${{ hashFiles('**/Cargo.lock') }}
-      
+
       - name: Run sccache-cache only on non-release runs
         if: github.event_name != 'release' && github.event_name != 'workflow_dispatch'
         uses: mozilla-actions/sccache-action@v0.0.3
@@ -72,26 +73,26 @@ jobs:
         run: |
           echo "SCCACHE_GHA_ENABLED=true" >> $GITHUB_ENV
           echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
-      
+
       - name: Run clippy check
         working-directory: avs-finalizer
         run: cargo clippy -- -D warnings
       # - name: Install cargo check tools
-        # run: |
-          # cargo install --locked cargo-deny || true
-          # cargo install --locked cargo-outdated || true
-          # cargo install --locked cargo-udeps || true
-          # cargo install --locked cargo-audit || true
-          # cargo install --locked cargo-pants || true
+      # run: |
+      # cargo install --locked cargo-deny || true
+      # cargo install --locked cargo-outdated || true
+      # cargo install --locked cargo-udeps || true
+      # cargo install --locked cargo-audit || true
+      # cargo install --locked cargo-pants || true
       # - name: Check
-        # working-directory: avs-finalizer
-        # run: |
-          # cargo deny check
-          # cargo outdated --exit-code 1
-          # cargo udeps
-          # rm -rf ~/.cargo/advisory-db
-          # cargo audit
-          # cargo pants
+      # working-directory: avs-finalizer
+      # run: |
+      # cargo deny check
+      # cargo outdated --exit-code 1
+      # cargo udeps
+      # rm -rf ~/.cargo/advisory-db
+      # cargo audit
+      # cargo pants
 
   tests:
     name: Run tests
@@ -105,7 +106,7 @@ jobs:
           override: true
           components: rustfmt, clippy
       - uses: arduino/setup-protoc@v3
-      
+
       - uses: google-github-actions/auth@v2
         with:
           workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
@@ -121,7 +122,7 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
           key: cargo-rollup-tests-cache-${{ inputs.cache_version }}-${{ hashFiles('**/Cargo.lock') }}
-      
+
       - name: Run sccache-cache only on non-release runs
         if: github.event_name != 'release' && github.event_name != 'workflow_dispatch'
         uses: mozilla-actions/sccache-action@v0.0.3
@@ -130,7 +131,7 @@ jobs:
         run: |
           echo "SCCACHE_GHA_ENABLED=true" >> $GITHUB_ENV
           echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
-      
+
       - name: Run tests
         working-directory: avs-finalizer
         run: cargo test
@@ -147,7 +148,7 @@ jobs:
           override: true
           components: rustfmt, clippy
       - uses: arduino/setup-protoc@v3
-      
+
       - uses: google-github-actions/auth@v2
         with:
           workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
@@ -163,7 +164,7 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
           key: cargo-rollup-compile-cache-${{ inputs.cache_version }}-${{ hashFiles('**/Cargo.lock') }}
-      
+
       - name: Run sccache-cache only on non-release runs
         if: github.event_name != 'release' && github.event_name != 'workflow_dispatch'
         uses: mozilla-actions/sccache-action@v0.0.3
@@ -172,14 +173,15 @@ jobs:
         run: |
           echo "SCCACHE_GHA_ENABLED=true" >> $GITHUB_ENV
           echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
-      
+
       - name: Run cargo build
         working-directory: avs-finalizer
         run: cargo build --release
-      
+
       - name: Create Docker image
         working-directory: avs-finalizer
         run: |
           docker login -u ${{ secrets.ORG_DOCKERHUB_USERNAME }} -p ${{ secrets.ORG_DOCKERHUB_TOKEN }}
           docker buildx create --use
           docker buildx build --push --platform linux/amd64 -t mangatasolutions/avs-finalizer:${{ inputs.version }} -f src/bin/Dockerfile .
+

--- a/avs-finalizer/src/bin/Dockerfile.local
+++ b/avs-finalizer/src/bin/Dockerfile.local
@@ -12,7 +12,7 @@ RUN set -eux && \
 		# apt clean up
 		apt-get autoremove -y && apt-get clean && rm -rf /var/lib/apt/lists/*
 
-ARG RUST_TOOLCHAIN=stable
+ARG RUST_TOOLCHAIN=1.78
 RUN rustup install $RUST_TOOLCHAIN && rustup default $RUST_TOOLCHAIN && \
 	rustup target add wasm32-unknown-unknown && \
 	rustup component add rust-src rustfmt clippy && \

--- a/stash-dev/src/connector/CoinGecko.ts
+++ b/stash-dev/src/connector/CoinGecko.ts
@@ -13,11 +13,13 @@ export const getCoinInfo = async (
   if (tokenId == null || tokenId.length <= 0)
     throw new BadRequestException('Missing token ID information.')
 
-  const coinDataResponse = await fetch(coinGeckoApi + '/coins/' + tokenId, {
+  const url = new URL(coinGeckoApi + '/coins/' + tokenId)
+  url.searchParams.append('x_cg_pro_api_key', process.env.COINGECKO_API_KEY!)
+
+  const coinDataResponse = await fetch(url, {
     method: 'get',
     headers: {
       Accept: 'application/json',
-      'x-cg-demo-api-key': process.env.COINGECKO_API_KEY!,
     },
   })
 
@@ -39,16 +41,20 @@ export const getCoinHistory = async (
   if (tokenId == null || tokenId.length <= 0)
     throw new BadRequestException('Missing token ID information.')
 
-  const coinDataResponse = await fetch(
-    `${coinGeckoApi}/coins/${tokenId}/market_chart?vs_currency=${currency}&days=${days}&interval=daily`,
-    {
-      method: 'get',
-      headers: {
-        Accept: 'application/json',
-        'x-cg-demo-api-key': process.env.COINGECKO_API_KEY!,
-      },
-    }
-  )
+  const url = new URL(`${coinGeckoApi}/coins/${tokenId}/market_chart`)
+  url.searchParams.append('vs_currency', currency)
+  url.searchParams.append('days', days.toString())
+  url.searchParams.append('interval', 'daily')
+  url.searchParams.append('x_cg_pro_api_key', process.env.COINGECKO_API_KEY!)
+
+  const headers = {
+    Accept: 'application/json',
+  }
+
+  const coinDataResponse = await fetch(url.toString(), {
+    method: 'get',
+    headers: headers,
+  })
 
   if (coinDataResponse.status !== HttpStatus.OK)
     throw new HttpResponseException(

--- a/stash-dev/src/connector/CoinGecko.ts
+++ b/stash-dev/src/connector/CoinGecko.ts
@@ -5,7 +5,7 @@ import {
 import fetch from 'cross-fetch'
 import { Decimal } from 'decimal.js'
 
-const coinGeckoApi = 'https://api.coingecko.com/api/v3'
+const coinGeckoApi = 'https://pro-api.coingecko.com/api/v3'
 
 export const getCoinInfo = async (
   tokenId: string


### PR DESCRIPTION
Replace coingecko information to pro (we are now on pro plan).
This change will be accompanied by change in COINGECKO_API_KEY secret. (for now repository secret is added to override organization one, when we propagate changes to all envs we will modify the organization secret)
First propagating this change on stash-dev to test behavior on dev and testnet stash envs. 