### PR TITLE
chore: bring back rollup env variable for deployment

### DIFF
--- a/.github/workflows/stash-rollup-dev.yml
+++ b/.github/workflows/stash-rollup-dev.yml
@@ -48,6 +48,7 @@ jobs:
           project_id: ${{ steps.auth.outputs.project_id }}
           env_vars: |-
             TIMESERIES_PASS=${{ secrets.TIMESERIES_PASS_ROLLUP_DEV }}
+            COINGECKO_API_KEY=${{ secrets.ORG_COINGECKO_API_KEY }}
           working_directory: stash-dev
           deliverables: app-rollup-dev.yaml
       

--- a/.github/workflows/stash-rollup-testnet.yml
+++ b/.github/workflows/stash-rollup-testnet.yml
@@ -48,6 +48,7 @@ jobs:
           project_id: ${{ steps.auth.outputs.project_id }}
           env_vars: |-
             TIMESERIES_PASS=${{ secrets.TIMESERIES_PASS_EIGEN }}
+            COINGECKO_API_KEY=${{ secrets.ORG_COINGECKO_API_KEY }}
           working_directory: stash-dev
           deliverables: app-rollup-testnet.yaml
       


### PR DESCRIPTION
Bringing back env variable for execution of deployment