### PR TITLE
fix: Update RPC URLs for Holesky environment configuration

### DIFF
--- a/ops/helmfiles/config/holesky.yaml
+++ b/ops/helmfiles/config/holesky.yaml
@@ -108,14 +108,14 @@ aggregatorEnvSecrets:
   ETH_RPC_URL: ref+sops://secrets.enc.yaml#/holeskyEthereumHttpsUrl
   ETH_WS_URL: ref+sops://secrets.enc.yaml#/holeskyEthereumWssUrl
 aggregatorEnv:
-  SUBSTRATE_RPC_URL: wss://rollup-holesky-rpc.gasp.xyz:443
+  SUBSTRATE_RPC_URL: ws://collator-01:9944
   CHAIN_ID: "17000"
   AVS_BLOCK_VALIDATION_PERIOD: '100'
   AVS_DEBOUNCE_RPC: '20'
   AVS_DEPLOYMENT_BLOCK: '1233400'
   AVS_KICK_PERIOD: '25'
   AVS_REGISTRY_COORDINATOR_ADDR: '0xfd6A45621DDfeBF94C082e60E0De92aA305a97a1'
-  AVS_RPC_URL: https://avs-aggregator-rpc-holesky.gasp.xyz
+  AVS_RPC_URL: http://avs-aggregator:8090
   AVS_SERVER_IP_PORT_ADDRESS: 0.0.0.0:8090
   AVS_TASK_EXPIRATION: '300'
   AVS_UPDATE_STAKE_PERIOD: '150'
@@ -139,14 +139,14 @@ finalizerEnvSecrets:
   ETH_RPC_URL: ref+sops://secrets.enc.yaml#/holeskyEthereumHttpsUrl
   ETH_WS_URL: ref+sops://secrets.enc.yaml#/holeskyEthereumWssUrl
 finalizerEnv:
-  SUBSTRATE_RPC_URL: wss://rollup-holesky-rpc.gasp.xyz:443
+  SUBSTRATE_RPC_URL: ws://collator-01:9944
   CHAIN_ID: "17000"
   AVS_BLOCK_VALIDATION_PERIOD: '100'
   AVS_DEBOUNCE_RPC: '20'
   AVS_DEPLOYMENT_BLOCK: '1233400'
   AVS_KICK_PERIOD: '25'
   AVS_REGISTRY_COORDINATOR_ADDR: '0xfd6A45621DDfeBF94C082e60E0De92aA305a97a1'
-  AVS_RPC_URL: https://avs-aggregator-rpc-holesky.gasp.xyz
+  AVS_RPC_URL: http://avs-aggregator:8090
   AVS_SERVER_IP_PORT_ADDRESS: 0.0.0.0:8090
   AVS_TASK_EXPIRATION: '300'
   AVS_UPDATE_STAKE_PERIOD: '150'


### PR DESCRIPTION
* Change SUBSTRATE_RPC_URL to local collator
* Update AVS_RPC_URL to use avs-aggregator
* Remove external Gasp URLs
* Adjust network configuration
* Improve internal service connectivity