### PR TITLE
fix: update configs for `collator-01` rpc connections in `rollup-holesky` environment

### DIFF
--- a/ops/helmfiles/config/holesky.yaml
+++ b/ops/helmfiles/config/holesky.yaml
@@ -40,7 +40,7 @@ collator:
     extraArgs:
       - --alith
       - --pruning=archive
-      - --rpc-max-connections=5000
+      - --rpc-max-connections=8000
     nodeSelector:
       production: "true"
       topology.kubernetes.io/zone: europe-west1-b
@@ -108,7 +108,7 @@ aggregatorEnvSecrets:
   ETH_RPC_URL: ref+sops://secrets.enc.yaml#/holeskyEthereumHttpsUrl
   ETH_WS_URL: ref+sops://secrets.enc.yaml#/holeskyEthereumWssUrl
 aggregatorEnv:
-  SUBSTRATE_RPC_URL: ws://collator-01:9944
+  SUBSTRATE_RPC_URL: ws://rpc-shared-dns-record:9944
   CHAIN_ID: "17000"
   AVS_BLOCK_VALIDATION_PERIOD: '100'
   AVS_DEBOUNCE_RPC: '20'
@@ -139,7 +139,7 @@ finalizerEnvSecrets:
   ETH_RPC_URL: ref+sops://secrets.enc.yaml#/holeskyEthereumHttpsUrl
   ETH_WS_URL: ref+sops://secrets.enc.yaml#/holeskyEthereumWssUrl
 finalizerEnv:
-  SUBSTRATE_RPC_URL: ws://collator-01:9944
+  SUBSTRATE_RPC_URL: ws://rpc-shared-dns-record:9944
   CHAIN_ID: "17000"
   AVS_BLOCK_VALIDATION_PERIOD: '100'
   AVS_DEBOUNCE_RPC: '20'
@@ -166,7 +166,7 @@ updaterMnemonicEth: ref+sops://secrets.enc.yaml#/updaterMnemonicEth
 updaterEnvEth:
   CHAIN: "holesky"
   L1_CHAIN: "Ethereum"
-  MANGATA_NODE_URL: ws://collator-01:9944
+  MANGATA_NODE_URL: ws://rpc-shared-dns-record:9944
   EIGEN_CONTRACT_ADDRESS: "0x0000000000000000000000000000000000000000"
   MANGATA_CONTRACT_ADDRESS: "0x93de6a193A839218BCA00c8D478256Ac78281cE3"
   FINALIZATION_SOURCE: "relay"
@@ -177,7 +177,7 @@ updaterMnemonicArb: ref+sops://secrets.enc.yaml#/updaterMnemonicArb
 updaterEnvArb:
   CHAIN: "arbitrum"
   L1_CHAIN: "Arbitrum"
-  MANGATA_NODE_URL: ws://collator-01:9944
+  MANGATA_NODE_URL: ws://rpc-shared-dns-record:9944
   EIGEN_CONTRACT_ADDRESS: "0x0000000000000000000000000000000000000000"
   MANGATA_CONTRACT_ADDRESS: "0x998AaF69F731009d4E2d470E974766F1EB8f5142"
   FINALIZATION_SOURCE: "relay"
@@ -196,7 +196,7 @@ secondSequencerMnemonicEth: "bottom drive obey lake curtain smoke basket hold ra
 sequencerChainUrlEth: ref+sops://secrets.enc.yaml#/holeskyEthereumHttpsUrl
 sequencerEnvEth:
   L1_CHAIN: "Ethereum"
-  MANGATA_NODE_URL: ws://collator-01:9944
+  MANGATA_NODE_URL: ws://rpc-shared-dns-record:9944
   MANGATA_CONTRACT_ADDRESS: "0x93de6a193A839218BCA00c8D478256Ac78281cE3"
   LIMIT: "100"
 
@@ -205,7 +205,7 @@ secondSequencerMnemonicArb: "bottom drive obey lake curtain smoke basket hold ra
 sequencerChainUrlArb: ref+sops://secrets.enc.yaml#/sepoliaArbitrumHttpsUrl
 sequencerEnvArb:
   L1_CHAIN: "Arbitrum"
-  MANGATA_NODE_URL: ws://collator-01:9944
+  MANGATA_NODE_URL: ws://rpc-shared-dns-record:9944
   MANGATA_CONTRACT_ADDRESS: "0x998AaF69F731009d4E2d470E974766F1EB8f5142"
   LIMIT: "100"
   


### PR DESCRIPTION
* increase client connections limit for collator-01 on rollup-holesky from 5000 to 8000 connections
* update configs for dependent services to connect through loadbalanced internal service endpoint instead of always connecting directly to collator-01 node