### PR TITLE
fix: update branch reference in main branch workflow for eth-rollup-develop

### DIFF
--- a/.github/workflows/branch-main.yml
+++ b/.github/workflows/branch-main.yml
@@ -77,7 +77,9 @@ jobs:
     uses: ./.github/workflows/reusable-gasp-node-generate-types.yml
     secrets: inherit
     with:
-      branch: ${{ needs.init.outputs.GIT_BRANCH_UNFORMATTED }}
+      # TODO: To be fixed when `eth-rollup-develop` branch in gasp-dev-kit is merged to `main`
+      # branch: ${{ needs.init.outputs.GIT_BRANCH_UNFORMATTED }}
+      branch: eth-rollup-develop
       globalVersion: ${{ needs.init.outputs.GLOBAL_VERSION }}
 
   run-e2e-test:


### PR DESCRIPTION
Change the branch reference in the main workflow to point directly to `eth-rollup-develop` for improved clarity and functionality.