### PR TITLE
Fix: Update bootnode addresses in production configuration

### DIFF
--- a/ops/helmfiles/config/prod.yaml
+++ b/ops/helmfiles/config/prod.yaml
@@ -43,7 +43,7 @@ collator:
   collator01:
     # Identity ID: 12D3KooWCnxPCDhnSDfw3WQReZxkyJ5fuQUFzVHmQx4SwVkd2Ndo
     customNodeKey: ref+sops://secrets.enc.yaml#/rollupProdCollator01CustomNodeKey
-    bootnodeAddr: /dns4/collator-02-p2p-rollup-prod.gasp.xyz/tcp/30333/ws/p2p/12D3KooWFGDFJken9CfwP1WRQ9MDANskcfZCeAVHTpE6utdhHM6Y
+    bootnodeAddr: /dns4/collator-02-p2p/tcp/30333/p2p/12D3KooWFGDFJken9CfwP1WRQ9MDANskcfZCeAVHTpE6utdhHM6Y
     accountKeys:
       - type: aura
         scheme: sr25519
@@ -60,7 +60,7 @@ collator:
   collator02:
     # Identity ID: 12D3KooWFGDFJken9CfwP1WRQ9MDANskcfZCeAVHTpE6utdhHM6Y
     customNodeKey: ref+sops://secrets.enc.yaml#/rollupProdCollator02CustomNodeKey
-    bootnodeAddr: /dns4/collator-01-p2p-rollup-prod.gasp.xyz/tcp/30333/ws/p2p/12D3KooWCnxPCDhnSDfw3WQReZxkyJ5fuQUFzVHmQx4SwVkd2Ndo
+    bootnodeAddr: /dns4/collator-01-p2p/tcp/30333/p2p/12D3KooWCnxPCDhnSDfw3WQReZxkyJ5fuQUFzVHmQx4SwVkd2Ndo
     accountKeys:
       - type: aura
         scheme: sr25519
@@ -78,7 +78,7 @@ collator:
     enabled: true
     # Identity ID: 12D3KooWMG7Benq1sMjRzgf1wATin9t61Rt88LuE1a5exx5WcPm9
     customNodeKey: ref+sops://secrets.enc.yaml#/rollupProdCollator03CustomNodeKey
-    bootnodeAddr: /dns4/collator-01-p2p-rollup-prod.gasp.xyz/tcp/30333/ws/p2p/12D3KooWCnxPCDhnSDfw3WQReZxkyJ5fuQUFzVHmQx4SwVkd2Ndo
+    bootnodeAddr: /dns4/collator-01-p2p/tcp/30333/p2p/12D3KooWCnxPCDhnSDfw3WQReZxkyJ5fuQUFzVHmQx4SwVkd2Ndo
     accountKeys:
       - type: aura
         scheme: sr25519
@@ -96,7 +96,7 @@ collator:
     enabled: true
     # Identity ID: 12D3KooWDq43eHqWDhW4J1gZpDuQDxUCKirD3sQvyjp9m5udxiEN
     customNodeKey: ref+sops://secrets.enc.yaml#/rollupProdCollator04CustomNodeKey
-    bootnodeAddr: /dns4/collator-01-p2p-rollup-prod.gasp.xyz/tcp/30333/ws/p2p/12D3KooWCnxPCDhnSDfw3WQReZxkyJ5fuQUFzVHmQx4SwVkd2Ndo
+    bootnodeAddr: /dns4/collator-01-p2p/tcp/30333/p2p/12D3KooWCnxPCDhnSDfw3WQReZxkyJ5fuQUFzVHmQx4SwVkd2Ndo
     accountKeys:
       - type: aura
         scheme: sr25519
@@ -111,19 +111,19 @@ collator:
     nodeSelector:
       topology.kubernetes.io/zone: europe-west1-c
   rpc01:
-    bootnodeAddr: /dns4/collator-01-p2p-rollup-prod.gasp.xyz/tcp/30333/ws/p2p/12D3KooWCnxPCDhnSDfw3WQReZxkyJ5fuQUFzVHmQx4SwVkd2Ndo
+    bootnodeAddr: /dns4/collator-01-p2p/tcp/30333/p2p/12D3KooWCnxPCDhnSDfw3WQReZxkyJ5fuQUFzVHmQx4SwVkd2Ndo
     nodeSelector:
       topology.kubernetes.io/zone: europe-west1-b
   rpc02:
-    bootnodeAddr: /dns4/collator-01-p2p-rollup-prod.gasp.xyz/tcp/30333/ws/p2p/12D3KooWCnxPCDhnSDfw3WQReZxkyJ5fuQUFzVHmQx4SwVkd2Ndo
+    bootnodeAddr: /dns4/collator-01-p2p/tcp/30333/p2p/12D3KooWCnxPCDhnSDfw3WQReZxkyJ5fuQUFzVHmQx4SwVkd2Ndo
     nodeSelector:
       topology.kubernetes.io/zone: europe-west1-c
   rpc03:
-    bootnodeAddr: /dns4/collator-01-p2p-rollup-prod.gasp.xyz/tcp/30333/ws/p2p/12D3KooWCnxPCDhnSDfw3WQReZxkyJ5fuQUFzVHmQx4SwVkd2Ndo
+    bootnodeAddr: /dns4/collator-01-p2p/tcp/30333/p2p/12D3KooWCnxPCDhnSDfw3WQReZxkyJ5fuQUFzVHmQx4SwVkd2Ndo
     nodeSelector:
       topology.kubernetes.io/zone: europe-west1-b
   rpcArchive01:
-    bootnodeAddr: /dns4/collator-01-p2p-rollup-prod.gasp.xyz/tcp/30333/p2p/12D3KooWCnxPCDhnSDfw3WQReZxkyJ5fuQUFzVHmQx4SwVkd2Ndo
+    bootnodeAddr: /dns4/collator-01-p2p/tcp/30333/p2p/12D3KooWCnxPCDhnSDfw3WQReZxkyJ5fuQUFzVHmQx4SwVkd2Ndo
     nodeSelector:
       topology.kubernetes.io/zone: europe-west1-b
 


### PR DESCRIPTION
Update the bootnode addresses in the production configuration to ensure proper connectivity.