### PR TITLE
fix: Increase instance class for `stash` service from B2 to B8 for better load handling

### DIFF
--- a/stash/app-prod.yaml
+++ b/stash/app-prod.yaml
@@ -35,7 +35,7 @@ env_variables:
 manual_scaling:
   instances: 1
 
-instance_class: B2
+instance_class: B8
 
 vpc_access_connector:
   name: 'projects/direct-pixel-353917/locations/europe-west6/connectors/redis-app-engine'


### PR DESCRIPTION
Upgrade the instance class from B2 to B8 to improve performance under load.
Ref: https://cloud.google.com/appengine/docs/standard?authuser=1#instance_classes