### PR TITLE
fix: Update EVM endpoints for closer service in gasp-prod to use Infura instead of Tenderly GASP-1921

### DIFF
--- a/ops/helmfiles/secrets.enc.yaml
+++ b/ops/helmfiles/secrets.enc.yaml
@@ -52,24 +52,24 @@ sequencerEthereumMainnetWssUrl: ENC[AES256_GCM,data:8MMFDLnvTtIziKtKjuWmLO2yw+Iz
 sequencerEthereumMainnetHttpsUrl: ENC[AES256_GCM,data:MtuGmrY6LyCAdJTAnHNriY6FaTGQyExWpSBJo+LYG7eQL4ozgRCnF4GDUKEKBQoWQmEhER88HhQI,iv:0hKHvDbFHCa330kY0r4rOOO0Nj7+2c5AwdUeBJpL50I=,tag:+YTDyW1N1jX6122byDSOvg==,type:str]
 ferryEthereumMainnetWssUrl: ENC[AES256_GCM,data:jUfVXHtsrxP6/us9F+NsvD/cEUJqEagln9NQq4RHtOKPEzU1lBoiop769YCUkw9kDLIBt6UcpBE=,iv:Yf1cG0MUFFe0CMaYhDZ2VqpQsydIs7hLCOVj5TYQt8w=,tag:6EHheIHyKNbE6hHUa3KDWQ==,type:str]
 ferryEthereumMainnetHttpsUrl: ENC[AES256_GCM,data:hXQgZkw6mJRMX9sioYJyACAG/oL2+Hdb2F+mQsDTV42jN8DOfKZdgR0UybvOlkOf3JLDNHhDiCrxIQ==,iv:ubzvlk0RcNacnpv7zBYqibevK5pCRZdCXlX6HZ2jTGY=,tag:g7GnqAH03obXwKJauiTSbg==,type:str]
-closerEthereumMainnetWssUrl: ENC[AES256_GCM,data:f62P+lDJiO/g8DQUMEGF02qMb4e2S24UQh/MB6zDQbkR+uvFNZUVWFdSYC0PoC2iQ6efuyQ0qFQ=,iv:kD8gV2lGY8mgsILt8BHr5Cn0wMP9YOq2nA69RTIowXM=,tag:1QEPZAptYND6Zx6qQe+Kyw==,type:str]
-closerEthereumMainnetHttpsUrl: ENC[AES256_GCM,data:Myk8j1CAM9nfBMxjVHtCTEdstZ3de2yDjvAorigV6RXnd2RM1fUm18LCajOzsVr5pbh6QCFLhdEvHw==,iv:C9kVGeMvq1gsZ6PvIEqdSWmTOSk04bV8sQS3ysr3u8A=,tag:W1qyiPYxqkDCt41zMOhSfQ==,type:str]
+closerEthereumMainnetWssUrl: ENC[AES256_GCM,data:yOAZoDdphRmQt8GwHIbRefJVPwAhRURUjNMVAtDoqFRXZMYjQLeDdF/WE1ukZfbHHnXrzIoRfeDbqLhEbvw=,iv:lMQ/yFUz3v3Wng5t82oV+9bYvt7S1b/9r/HeXPgXWnI=,tag:WExLotvVR46u5PKsfk0lTA==,type:str]
+closerEthereumMainnetHttpsUrl: ENC[AES256_GCM,data:/+66ChCUx6bOIaVybTQq+/AAXeop7SM13mNzWerxqnnABtzX7yNcU0glT1W8MZpIxn4f3504Lkee3HgSfA==,iv:wTWU0HN6PP+PS5mDN9v0j6TjHkKRjE5LK0qhVG8piLU=,tag:PaI6wrfwwlMvuN++HycFjQ==,type:str]
 updaterArbitrumMainnetWssUrl: ENC[AES256_GCM,data:6Q7BxdjZtOS64P2/QGtP5GT68rsGmAadOiMGUBrxiFHuDs+S2FQVmYqpFt+2lsBhxlLpIMuw9Kw=,iv:Y6DBIRghSZpQLpuHB4bCg+BADiPLjzk8D65KP1Z8ZgI=,tag:aa7IfjH8CQNo908vDaHO1Q==,type:str]
 updaterArbitrumMainnetHttpsUrl: ENC[AES256_GCM,data:SlMl+Ky7FqTP8pElzfENZ/pSpn/6PPK7c90yCajC8S/32WVBOVE5fkIFWQihNjAc4PLVchUN5Atstg==,iv:Ndy+3p3OaQ9ZiRAw8jQX7x0Oop2GVONnmjpj8E33qNA=,tag:r13EdcnFrt2/p7aQdhPbwg==,type:str]
 sequencerArbitrumMainnetWssUrl: ENC[AES256_GCM,data:ggBzCGNUOt8KYoS70Ukzj7R+gUyiPEniq7nORS7IsP4M28HedyBBYrOZdXoyiSe0GlGITsAtubBq,iv:y2Aj3kiK7FALYDxeA6tsCfNgLHITE6e3aVWNVc3kkbE=,tag:XQkcVtVqBaV+4La4Jm5qHg==,type:str]
 sequencerArbitrumMainnetHttpsUrl: ENC[AES256_GCM,data:yqpTDpsjqLe1eI07/Xeb33Q2UJ30blZbZwMHi6YfP7KPskQBe0+PWSoddY7qhqjtSNSYzj1kqlQEs0o=,iv:Ulc/6wDOb66v7kmj/HYq288jGz2o60bjdtEFkjHS5BY=,tag:7UVAPrEFyM4jfLJBl3nhAA==,type:str]
 ferryArbitrumMainnetWssUrl: ENC[AES256_GCM,data:CHndjxuEf6mTwGCt/gDvYWR2/oKk0S7g1u/MhX3SpAi2TQp/orDKlQSA+6/wCOVUyeJtgdco0qG3,iv:SiS55XRD1EZ5qO9WJLoi5J+8ddf7ohQ8uMvkwz+3AKc=,tag:AKEBuTTdoLfD1LTOwIxIJA==,type:str]
 ferryArbitrumMainnetHttpsUrl: ENC[AES256_GCM,data:25Hw19Zk24w8RCZFDizJYsVpyax8j7r8IWjKOH15Rg9Nb8ibJ58pq8bqJiGp3KX20gNkZ/clZZcAtiQ=,iv:YPXUPRSqdDGOirc8EAnDDa9E3UXoteZiOA6SyUzBZ9Y=,tag:97C4anhxQRm/cTIZNed9CA==,type:str]
-closerArbitrumMainnetWssUrl: ENC[AES256_GCM,data:9OT+R0vHRa4nMpAw+CNTFor5610MIFpHjkeKsoERzsAyjiIl/beUloYw/moLOJ2ebmep3xW1RECL,iv:imYK0psYA09N93EzB0B4edULyFWOhRdaRCFD30gUBHc=,tag:mXkuU/Hvr0rIRCpv7gh9Sg==,type:str]
-closerArbitrumMainnetHttpsUrl: ENC[AES256_GCM,data:F3yMcZqfuV/kWufVHIL8q4kL+wSVigB8YUFd061+T8e0ivSznJvde/folfYm1fsdMizc7+ajC67F+hg=,iv:sS8fqhSVI+ZTn2wnSNlaMH+kao3eV2Ky9lwZqfLKsF0=,tag:k2793RQ2pBBFULsH4XTAJg==,type:str]
+closerArbitrumMainnetWssUrl: ENC[AES256_GCM,data:TrIfSUyq5+eiKNHD+pSC9D9c9z6wFfQmuJDhhXPPjO8lHL1jVnXjuTQui4/x3PZXoakc5+h5YyunsnNypV4kknnWT0ukXTo=,iv:GYyOBoD1kXjAKeC+vSw7rz5sHqpoeCE9xzTZmRkozFw=,tag:K5XBSRq/DZTJwTluUcVLBw==,type:str]
+closerArbitrumMainnetHttpsUrl: ENC[AES256_GCM,data:wpBJdzNWrYcksv6h5SbBTDaDz+G4zcejqDBAMxab5eB/2ZN0wTqrAXXEfKzM1mq9hsq2/zFiA+Ase6YPMxX/pX4rUDicJg==,iv:hiYa2KMmFV/TQq/NxzCsBHAfe2cMFShc3N+p5SGwffY=,tag:MogzFW41Hrdvelt+A0jTvg==,type:str]
 updaterBaseMainnetWssUrl: ENC[AES256_GCM,data:vBhtUZhrKOfmRV83BvDsAQ422gpzfQdnMh8F1EOdz0mrGUHW8EM99F/P1Rt/Bb6crLE+KQg=,iv:3rWCGwPeHTSgYil/1tyYi4jgPRUPXC44YPESvKWENsA=,tag:4vWdXOY1eOc2yVgyYdmkEw==,type:str]
 udpaterBaseMainnetHttpsUrl: ENC[AES256_GCM,data:VQeZXzzusaATR0LgYWA7u5Or8DIbA85Ke5cZ6At5NGZqrOCdb2SCamL31mvtRknWLFk8nQhPig==,iv:eySM3kyPfguSx9nBAwcZGXlrwlAyPOGZ83YUqjPItmw=,tag:tS2Qq7hwPgxU7AvI0cSbYA==,type:str]
 sequencerBaseMainnetWssUrl: ENC[AES256_GCM,data:h9aTtqtMju5VhUUtRBnBqgZTeDAT5Uvn8aad7YBiq3CQ3/oJBLN4rXoDzj/5Dm2JKaZKKr4wmzG9gHjX7pBJsPifNg==,iv:sRNuzcm+zFMFeaeG2pOIK+egH3Ge5oEpy/EAv7Ua3CM=,tag:VHWykBe4elRKRYcJLnnHlw==,type:str]
 sequencerBaseMainnetHttpsUrl: ENC[AES256_GCM,data:EaZ4HHg7t8ImWj08euKafr6B4ecYICSZekzCmHcaVyXT+I8SBa9W0jI5Hc67dgU3+vdvZklM0kHmlrFlF/2hfdoJ,iv:sCPG7wVeRnKzBf5LDWvHQT2qxX+JIQRrkdHiMnvkBWI=,tag:0AKJYkR0j8i6RWI/0w9HRw==,type:str]
 ferryBaseMainnetWssUrl: ENC[AES256_GCM,data:ZcSplSuXUlXv/MvKqaq5M0ti3igk8k/CEFWFTo5f11z0lZyOodFFaLHbCjyQVG6zoPrGHBE=,iv:PRTuEK8zTGpcHiTZwuC0ex6ue6yP6y5ACt0g4gbFFYA=,tag:WaWs7cXPCXZPnJE3ukj4Uw==,type:str]
 ferryBaseMainnetHttpsUrl: ENC[AES256_GCM,data:qZf3um2yIbsIMuBJL4ZVAJs98LUvmi1kqr/JfxMIMkrKb66qvxJeceGMbQ24qAxVSMQmpPPdag==,iv:++yJilUR87pEfncu/vpI5tokr7dPnfMxuB3LPwTq1VA=,tag:GXcYBf+c2+578NFSaYxNCw==,type:str]
-closerBaseMainnetWssUrl: ENC[AES256_GCM,data:ClHT6t0wQt5fKVWPkmcNk2az3lkohZwc5UHAatT+gLAThd45ltaRVSap4odIppHuug0hTYU=,iv:y8spS1TZTaf0W0q55QnHJXmGV9DL/Xr3qE6VeDL+3F4=,tag:p/N4i+ngPep4QEcTyLEYWw==,type:str]
-closerBaseMainnetHttpsUrl: ENC[AES256_GCM,data:nGUHD2/lafe90cPx2IFGq9tTh502eyDvl7whdjXwVG6mA4wgFP/OeigUBn56wb9xGQOtbOCQuA==,iv:SedVZBL50LlmOLXqPKfNBfiA4HfyJ0RJwV2Q5yg+vDc=,tag:i+cLaWXUZ1Ltbh15MpFCfw==,type:str]
+closerBaseMainnetWssUrl: ENC[AES256_GCM,data:dk68OwF2pqoMWg5uEIvkdeYTihNBYSOxVO1zS8BYvSiI9NlV8zjVYa2c6aVxwWAzAFfFtCbW7ZMfa5ekglJReGs7Ig==,iv:clglbRpIijIXepSO+ey3JND+BUbyLhAqZ4wvMhDUYRk=,tag:0kk/7Lm7vUO5YasxOZVl4g==,type:str]
+closerBaseMainnetHttpsUrl: ENC[AES256_GCM,data:nfOSvvjASTFCMNEiNutc12ib43hkeZpBvWt6SGR6lU4f3TfVV40p66VFF1TCgIew+FhOkHWNc/v1wTvt4TK3+oKC,iv:pVx2xHv8UHpKrnOpFxMw/zdyEpj70CXjXKAaY/T6Jhg=,tag:l220XEpQ2MBvyyzgXyEBkw==,type:str]
 sops:
     kms: []
     gcp_kms:
@@ -79,8 +79,8 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2025-01-21T15:36:03Z"
-    mac: ENC[AES256_GCM,data:IWwDKvv9PGbd7nXpnRUwTmWqHH8xjvUfDWjk+2rikqUnd5EJEU0LRH+aParVB5vDoFQHwgRDq0aGALcoPCKS1iQYa853jHomC6WeguzQr2H1FASlUbhy8D4JHhVIBD8dWfHACw1aJsQ1Og2ur0/x7HwI+b3MtAJkyH+PCbOM8z4=,iv:EUbaY41PIkdK2YpguRJ759sUdvgpe0ZzZjUWwvsfMW0=,tag:HnXcOhiO9JxX4a2RDyObcw==,type:str]
+    lastmodified: "2025-02-06T10:16:02Z"
+    mac: ENC[AES256_GCM,data:/noXOhPKPqIvBtnzsJxL2dOxXO7kCODywxkgBDPBYx2zaa2Eva2uLYZWOUmxHWExEytcOKAayePr8AYW6BvGqjctZpHf9Pm1id5UxSVVYkb7D2rMS2KCirIo4Y+CpkQdIGIuhQIq2adM8FXa4tskUxmUrNQyNGHDHIHcL36YUW0=,iv:r1hOoZbIDE8njNsTriH2F971W4StGUNnYN70kfsv6PA=,tag:MwqkrH9hpGnetgK5VCLc4Q==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
-    version: 3.9.1
+    version: 3.9.3


### PR DESCRIPTION
GASP-1921