### PR TITLE
chore: enable BlockScout in staging configuration

### DIFF
--- a/ops/helmfiles/config/staging.yaml
+++ b/ops/helmfiles/config/staging.yaml
@@ -1,5 +1,5 @@
 remoteCluster: true
-blockscoutEnabled: false
+blockscoutEnabled: true
 enableArbitrumServices: true
 enableBaseServices: true
 ##################################


### PR DESCRIPTION
Enable BlockScout in the staging environment to facilitate testing and development.