### PR TITLE
Update updater-base RPC URLs to Infura endpoints

### DIFF
--- a/ops/helmfiles/secrets.enc.yaml
+++ b/ops/helmfiles/secrets.enc.yaml
@@ -64,8 +64,8 @@ ferryArbitrumMainnetWssUrl: ENC[AES256_GCM,data:CHndjxuEf6mTwGCt/gDvYWR2/oKk0S7g
 ferryArbitrumMainnetHttpsUrl: ENC[AES256_GCM,data:25Hw19Zk24w8RCZFDizJYsVpyax8j7r8IWjKOH15Rg9Nb8ibJ58pq8bqJiGp3KX20gNkZ/clZZcAtiQ=,iv:YPXUPRSqdDGOirc8EAnDDa9E3UXoteZiOA6SyUzBZ9Y=,tag:97C4anhxQRm/cTIZNed9CA==,type:str]
 closerArbitrumMainnetWssUrl: ENC[AES256_GCM,data:9OT+R0vHRa4nMpAw+CNTFor5610MIFpHjkeKsoERzsAyjiIl/beUloYw/moLOJ2ebmep3xW1RECL,iv:imYK0psYA09N93EzB0B4edULyFWOhRdaRCFD30gUBHc=,tag:mXkuU/Hvr0rIRCpv7gh9Sg==,type:str]
 closerArbitrumMainnetHttpsUrl: ENC[AES256_GCM,data:F3yMcZqfuV/kWufVHIL8q4kL+wSVigB8YUFd061+T8e0ivSznJvde/folfYm1fsdMizc7+ajC67F+hg=,iv:sS8fqhSVI+ZTn2wnSNlaMH+kao3eV2Ky9lwZqfLKsF0=,tag:k2793RQ2pBBFULsH4XTAJg==,type:str]
-updaterBaseMainnetWssUrl: ENC[AES256_GCM,data:vBhtUZhrKOfmRV83BvDsAQ422gpzfQdnMh8F1EOdz0mrGUHW8EM99F/P1Rt/Bb6crLE+KQg=,iv:3rWCGwPeHTSgYil/1tyYi4jgPRUPXC44YPESvKWENsA=,tag:4vWdXOY1eOc2yVgyYdmkEw==,type:str]
-udpaterBaseMainnetHttpsUrl: ENC[AES256_GCM,data:VQeZXzzusaATR0LgYWA7u5Or8DIbA85Ke5cZ6At5NGZqrOCdb2SCamL31mvtRknWLFk8nQhPig==,iv:eySM3kyPfguSx9nBAwcZGXlrwlAyPOGZ83YUqjPItmw=,tag:tS2Qq7hwPgxU7AvI0cSbYA==,type:str]
+updaterBaseMainnetWssUrl: ENC[AES256_GCM,data:RM5xfvI8Si2smcp6vqbYdoJfEl85eyquy+XpR7mLcQ/0sO8AV5f9YZxUc9zeGxfVz04WU0MZOWCwxwQrrmVKG/1O9w==,iv:mUwYDgs6Tj10PSGn9aA44PtEwohzXic+Tzm01FR5qYs=,tag:1XGnNU2lri2M0uW7R0nl1w==,type:str]
+udpaterBaseMainnetHttpsUrl: ENC[AES256_GCM,data:xb57EMwq7xiMkS9f4hv0k8sWG+benrOvWsxDw/VGjWF9z2NnXiXujaiBH2aaGFb7wIyUnVrtsGQdIV4ozvYUzNN5,iv:Pswhjh6K2dcZBDngO0UmWYXzOGJvSLTI0D2K3PPGJHE=,tag:8GGsbXV/f9o8s1JNMt8rLw==,type:str]
 sequencerBaseMainnetWssUrl: ENC[AES256_GCM,data:h9aTtqtMju5VhUUtRBnBqgZTeDAT5Uvn8aad7YBiq3CQ3/oJBLN4rXoDzj/5Dm2JKaZKKr4wmzG9gHjX7pBJsPifNg==,iv:sRNuzcm+zFMFeaeG2pOIK+egH3Ge5oEpy/EAv7Ua3CM=,tag:VHWykBe4elRKRYcJLnnHlw==,type:str]
 sequencerBaseMainnetHttpsUrl: ENC[AES256_GCM,data:EaZ4HHg7t8ImWj08euKafr6B4ecYICSZekzCmHcaVyXT+I8SBa9W0jI5Hc67dgU3+vdvZklM0kHmlrFlF/2hfdoJ,iv:sCPG7wVeRnKzBf5LDWvHQT2qxX+JIQRrkdHiMnvkBWI=,tag:0AKJYkR0j8i6RWI/0w9HRw==,type:str]
 ferryBaseMainnetWssUrl: ENC[AES256_GCM,data:ZcSplSuXUlXv/MvKqaq5M0ti3igk8k/CEFWFTo5f11z0lZyOodFFaLHbCjyQVG6zoPrGHBE=,iv:PRTuEK8zTGpcHiTZwuC0ex6ue6yP6y5ACt0g4gbFFYA=,tag:WaWs7cXPCXZPnJE3ukj4Uw==,type:str]
@@ -85,8 +85,8 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2025-02-12T08:59:30Z"
-    mac: ENC[AES256_GCM,data:igsfu28GIjlR4HWjF+lIrJb0ENWGKvP2nfPEaL00mMaPouXrapI7h7MU5SjIedPhE9gd4lDORb7Vxhf9x8K11JcxY+A/IfkkxlfVePodHYbAj6bniwDXx8PyKXGrDXkdYbbgOr0b26jD7QXb70g7krgDe4SW2d6fJh2tB9NuOtk=,iv:ThjLfEyb0acA990aWHaIrMXfHr/mEY89VIHbvb0Tacs=,tag:dmStgSMne1T3j+UM2ZEwsA==,type:str]
+    lastmodified: "2025-02-24T10:34:18Z"
+    mac: ENC[AES256_GCM,data:81//O99GZ58X82A2Zq0SxQUs5A6g5g2vcx+AyAyASTeQREWEXoQp9d9lID945WvGeKIZqiXrEk1CxZlNI7Jqx8q9h5aqAgm4p0gJToHLj0JPzD8zlDIlrX1jO08JtWHiDRymD3oTDQ3PCwh0y6o3NktFNNjfeLjaTQrBEcxMIqk=,iv:ZYFdLKybLnU7Av1EgHDJgdg8Fsw9wICiz5vTQJGZ2uY=,tag:HV1ln1XXAh5eyZyNEzbDkg==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
-    version: 3.9.1
+    version: 3.9.4


### PR DESCRIPTION
Replace the updater-base RPC URLs with Infura endpoints and update the last modified date and version in the configuration.