### PR TITLE
ci: disable moon cache usage for e2e tests workflow running on `release/next` branch

### DIFF
--- a/.github/workflows/reusable-e2e-tests-new.yml
+++ b/.github/workflows/reusable-e2e-tests-new.yml
@@ -207,7 +207,11 @@ jobs:
       - uses: moonrepo/setup-toolchain@v0.4.0
         with:
           cache-version: ${{ env.CACHE_VERSION }}
-      # - run: moon setup
+      
+      - name: Set MOON_CACHE=off for release/next branch
+        if: github.ref_name == 'release/next'
+        run: echo "MOON_CACHE=off" >> $GITHUB_ENV
+      
       - name: Run tests
         run: ${{ matrix.command }}
         env:


### PR DESCRIPTION
Added a step to set MOON_CACHE=off when running tests on the release/next branch to prevent caching issues during the e2e tests. This should help ensure more reliable test results.