### PR TITLE
chore: update concurrency group in branch-main.yml for improved workflow isolation

### DIFF
--- a/.github/workflows/branch-main.yml
+++ b/.github/workflows/branch-main.yml
@@ -25,9 +25,9 @@ permissions:
   issues: write
   pull-requests: write
 
-# The following concurrency group queus in-progress jobs
+# The following concurrency group ensures workflows on different branches run independently
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref }}
+  group: ${{ github.workflow }}-${{ github.ref_name }}
   cancel-in-progress: false
 
 jobs:


### PR DESCRIPTION
Changed the concurrency group identifier from `${{ github.head_ref }}` to `${{ github.ref_name }}` to ensure workflows on different branches run independently. This adjustment enhances the reliability of our CI/CD processes by preventing potential conflicts between concurrent jobs.